### PR TITLE
Small changes to tag wrapping

### DIFF
--- a/src/ui/TagMenu.svelte
+++ b/src/ui/TagMenu.svelte
@@ -265,7 +265,7 @@
     padding: 4px 10px;
     border-radius: 8px; /* large/long tags look really weird with circle pills, changed it to be a lil round */
     border: none; /* personal taste with below bg color */
-    background: rgba(0, 0, 0, 0.1);
+    background: rgba(0, 0, 0, 0.1); /* i have this set to a variable in my theme, background-secondary could be an option */
     font-weight: bold;
     font-size: 12px;
     margin: 2px 2px 2px 2px;

--- a/src/ui/TagMenu.svelte
+++ b/src/ui/TagMenu.svelte
@@ -225,7 +225,7 @@
   }
 
   .link:hover {
-    background: var(--color-accent); /* color-accent seems to match the rest of the ui a little better for me personally >.< */
+    background: var(--interactive-accent);
     color: var(--text-on-accent);
 
     padding-left: 4px;
@@ -278,7 +278,7 @@
   }
 
   .btn:hover {
-    background: var(--color-accent);
+    background: var(--interactive-accent);
     color: var(--text-on-accent);
   }
 

--- a/src/ui/TagMenu.svelte
+++ b/src/ui/TagMenu.svelte
@@ -177,6 +177,11 @@
 
   .align-center {
     align-items: center;
+    margin: 8px;
+    overflow: visible;
+    justify-content: flex-start;
+    display: flex;
+    flex-wrap: wrap; /* have tags wrap instead of scroll, so long tags don't break to a new line */
   }
 
   .flex-wrap {
@@ -220,7 +225,7 @@
   }
 
   .link:hover {
-    background: var(--interactive-accent);
+    background: var(--color-accent); /* color-accent seems to match the rest of the ui a little better for me personally >.< */
     color: var(--text-on-accent);
 
     padding-left: 4px;
@@ -258,13 +263,13 @@
   .btn {
     cursor: pointer;
     padding: 4px 10px;
-    border-radius: 100px;
-    border: 1px solid var(--interactive-accent);
+    border-radius: 8px; /* large/long tags look really weird with circle pills, changed it to be a lil round */
+    border: none; /* personal taste with below bg color */
+    background: rgba(0, 0, 0, 0.1);
     font-weight: bold;
     font-size: 12px;
-    margin-right: 10px;
-
-    transition: all 0.2s ease;
+    margin: 2px 2px 2px 2px;
+    transition: all 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940);
   }
 
   .btn.muted {
@@ -273,7 +278,7 @@
   }
 
   .btn:hover {
-    background: var(--interactive-accent);
+    background: var(--color-accent);
     color: var(--text-on-accent);
   }
 


### PR DESCRIPTION
Hey! I _really_ love this plugin, it is pretty much _exactly_ what I needed, without having to delve too far into Dataview; tysm for your work on it :)

Using it, I did make a few small changes to how tags are handled for my own use. I hope you don't mind, but I did try to convert the changes from my theme to a pull request. Totally feel free to disregard but thought I might toss over what I have!

I noticed that long tags (#like-this-example) often looked a little weird with border-radius 100px and no wrap. My solution was to have all the tags wrap in view. Obviously, this is personal preference, but feel free to do whatever with this :)

![image](https://user-images.githubusercontent.com/87339163/216446180-e304af28-0b9c-42cc-8e4a-460809fdf62c.png)
