### PR TITLE
Fix: View not refreshing after clicking

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -69,7 +69,7 @@ export default class CRNView extends ItemView {
     }
 
     this.unsubscribe = this.tagMenuStore.subscribe(_ => {
-      this.app.workspace.requestSaveHistory()
+      this.app.workspace.requestSaveLayout()
     })
 
     return Promise.resolve()


### PR DESCRIPTION
Being very interested by the plugin's features, I downloaded it. When using it, I was forced to reopen it each time to see the changes that were made after each click. Since I didn't find any alternative plugin, I troubleshooted it.

After comparing the constructor "Workspace" properties with the Error message in the console. I found that the property used was incorrect. When I changed it from the one in the source code (requestSaveHistory) to the one I proposed (requestSaveLayout), it finally started behaving normally.

Your plugin is a life saver and I've been pleasured to contribute, even a bit, to it.